### PR TITLE
Update config to enable docfx v3

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -32,5 +32,8 @@
     }
   ],
   "branch_target_mapping": {},
-  "need_generate_pdf_url_template": false
+  "need_generate_pdf_url_template": false,
+  "docs_build_engine": {
+    "name": "docfx_v3"
+  }
 }


### PR DESCRIPTION
The Docs Build v3 migration script has been run against your repository, and a new _**docs-build-v3**_ branch has been created. The migration tool was run and found no issues. 

Merging this PR completes the migration process. This enables the new DocFX engine. 

Here is the list of currently supported features for [Docs Build v3](https://review.docs.microsoft.com/en-us/engineering/projects/ops/ops-build-docfx-v3-supported-features?branch=master).
- Improved Build performance
- Faster iterations to improve Docs.com build pipeline
- Lowered operating costs
- Improved support for SRE and Engineering to perform troubleshooting
- Latest version of DocFX
