### PR TITLE
Linkfix: Azure DevOps Extensions (2021-06)

### DIFF
--- a/extensions/dependency-tracker/Dependency-Views.md
+++ b/extensions/dependency-tracker/Dependency-Views.md
@@ -12,11 +12,11 @@ ms.date: 07/15/2019
 
 Shows dependencies that an area path is consuming from other area paths. These are all of the dependencies you are receiving from other teams.
 
-![Consuming-View](../images/Consuming-View.png)
+![dependencies you are receiving from other teams](../images/Consuming-View.png)
 
 On the bar chart each column represents another area path that is producing dependencies for this area path by state or risk.  The table below shows a list of all of the associated work items.
 
-## Options in this view
+## Options in consuming dependencies chart
 
 - Filtering down work items
 - Changing if the Producer or Consumer work items are displayed on top
@@ -28,7 +28,7 @@ Shows dependencies that an area path is producing for other area paths. These ar
 
 ![Dependency Tracker](../images/Producing-View.png)
 
-## Options in this view
+## Options in producing dependencies chart
 
 - Filtering down work items
 - Changing if the Producer or Consumer work items are displayed on top

--- a/extensions/index.md
+++ b/extensions/index.md
@@ -11,4 +11,4 @@ ms.date: 05/17/2018
 
 The Azure DevOps Marketplace offers a wide variety of extensions to customize or enhance the default experience. The following documentation details extensions developed by Microsoft.
 
-[Dependency Tracker](https://docs.microsoft.com/azure/devops/extensions/dependency-tracker/overview)
+[Dependency Tracker](./dependency-tracker/overview.md)


### PR DESCRIPTION
This PR is the result of running a Link Repair script on the included content. This script is primarily being run to cleanup links to function correctly in Air Gapped Clouds (AGC). Here's a breakdown of what the script that generated the changes in this PR fixes:

- docs.microsoft.com Fully Qualified Domain Name (FQDN) Links to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not
- azure.microsoft.com/documentation/articles that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not
- All known flavors of MSDN/TechNet domains (we know of 8 or 9 now) that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not
  - This also includes cleanup of the appended query string for MSDN (redirectedfrom=MSDN).
- Fixes articles that are redirected in `.openpublishing.redirection.json` and updates the link to the current final location (this has a lot of customer usability fixes).

Please note the [Contributor Guide: Links](https://review.docs.microsoft.com/en-us/help/contribute/links-how-to?branch=master) has been updated with the following link-type preference order:

```
By order of preference, links hosted on Docs should be Relative if they are in the same repository and docset. If they are in a different docset, even if in the same repository, they should be Site Relative. Links to content hosted on Docs shouldn't use a complete URL, otherwise known as Fully Qualified Domain Names (FQDN). Using a complete URL from Docs to other content on Docs will cause that link to be non-functional in air-gap environments.
```