### PR TITLE
Update overview.md

### DIFF
--- a/extensions/dependency-tracker/overview.md
+++ b/extensions/dependency-tracker/overview.md
@@ -12,6 +12,7 @@ ms.date: 07/15/2019
 Dependency Tracker Extension provides users with the ability to plan and manage dependencies across areas by providing a clear visual of all dependencies a team is consuming and producing.  The view allows user to view the state of the dependencies as well as the timing to asses the risk of the dependencies.  It is used to plan dependencies at the beginning of an iteration or release as well as to track the status during development.  
 
 Consuming Dependencies - work the selected area path is dependent on other area paths to complete
+
 Producing Dependencies - work the selected area path is doing that other area paths are dependent on
 
 Dependency Tracker appears under Boards


### PR DESCRIPTION
Added extra space to separate Consuming and producing dependency lines in the text.  Right now they are displayed on the same line because of the way Markdown is rendered.  It's confusing when you read it with this formatting